### PR TITLE
UI tweaks

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -22,6 +22,7 @@ import 'package:orbit/data/radar_overlay.dart';
 import 'package:orbit/data/weather/tabular_weather_state.dart';
 import 'package:orbit/debug_tools_stub.dart'
     if (dart.library.io) 'package:orbit/debug_tools.dart';
+import 'package:orbit/platform/android_platform_settings.dart';
 
 class AppState extends ChangeNotifier {
   static const int favoritesPerMonitorCapacity = 60;
@@ -43,6 +44,7 @@ class AppState extends ChangeNotifier {
   bool debugMode = false;
   bool analyticsDisabled = false;
   bool smallScreenMode = false;
+  bool androidImmersiveMode = false;
   double safeAreaInsetScale = 1.0;
   // Android-only: preferred audio output route
   String androidAudioOutputRoute = 'Speaker';
@@ -424,6 +426,11 @@ class AppState extends ChangeNotifier {
       defaultValue: false,
     );
 
+    androidImmersiveMode = await storageData.load(
+      SaveDataType.androidImmersiveMode,
+      defaultValue: false,
+    );
+
     // Safe-area scale
     final dynamic rawSafeAreaScale = await storageData.load(
       SaveDataType.safeAreaInsetScale,
@@ -790,6 +797,13 @@ class AppState extends ChangeNotifier {
         };
       } catch (_) {}
     }
+    notifyListeners();
+  }
+
+  void updateAndroidImmersiveMode(bool enabled) {
+    androidImmersiveMode = enabled;
+    storageData.save(SaveDataType.androidImmersiveMode, enabled);
+    AndroidPlatformSettings.applyImmersiveMode(enabled);
     notifyListeners();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1106,7 +1106,6 @@ class MainPageState extends State<MainPage>
         if (!opened) {
           throw StateError('Aux input did not become active');
         }
-        onMessage('Head Unit Audio', 'Switched to Aux input.');
         return;
       } catch (e, st) {
         // If native Aux fails, disable it and fall back to USB audio setup
@@ -1138,7 +1137,6 @@ class MainPageState extends State<MainPage>
         try {
           final opened = await HeadUnitAux.switchToAux(timeoutMs: 1500);
           if (!opened) throw StateError('Aux input did not become active');
-          onMessage('Head Unit Audio', 'Switched to Aux input.');
           return;
         } catch (e, st) {
           logger.e('Failed to switch to aux input', error: e, stackTrace: st);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -173,10 +173,7 @@ class OrbitApp extends StatelessWidget {
 
               return MediaQuery(
                 data: next,
-                child: LogOverlayHost(
-                  enabled: appState.logOverlayEnabled,
-                  child: child ?? const SizedBox.shrink(),
-                ),
+                child: child ?? const SizedBox.shrink(),
               );
             },
             home: const MainPage(),
@@ -2762,6 +2759,9 @@ class MainPageState extends State<MainPage>
                   ],
                 ),
               ),
+            Positioned.fill(
+              child: FloatingLogLayers(enabled: appState.logOverlayEnabled),
+            ),
           ],
         );
       },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,9 +38,11 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:orbit/ui/unsupported_browser_app.dart';
 import 'package:orbit/ui/favorite_dialog.dart';
 import 'package:orbit/ui/favorites_on_air_dialog.dart';
+import 'package:orbit/ui/small_screen_mode_confirm_dialog.dart';
 import 'package:orbit/ui/welcome_dialog.dart';
 import 'package:orbit/ui/connection_dialogs.dart';
 import 'package:orbit/platform/android_platform_settings.dart';
+import 'package:orbit/platform/display_heuristics.dart';
 import 'package:orbit/platform/head_unit_aux.dart';
 import 'package:orbit/ui/log_overlay.dart';
 
@@ -314,6 +316,11 @@ class MainPageState extends State<MainPage>
       logger.i('AudioSession configured success');
       _startAudioFocusMonitoring();
 
+      // Android first run on compact displays: confirm Small Screen Mode before Welcome.
+      try {
+        await _maybeShowSmallScreenAutoConfirmDialog();
+      } catch (_) {}
+
       // Show first-time welcome
       if (!appState.welcomeSeen) {
         try {
@@ -550,6 +557,23 @@ class MainPageState extends State<MainPage>
         );
       },
     );
+  }
+
+  /// Android first run ([welcomeSeen] false): ask before enabling Small Screen Mode
+  /// when the display heuristic matches compact / automotive layouts.
+  Future<void> _maybeShowSmallScreenAutoConfirmDialog() async {
+    if (kIsWeb ||
+        kIsWasm ||
+        defaultTargetPlatform != TargetPlatform.android ||
+        appState.welcomeSeen) {
+      return;
+    }
+    try {
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted) return;
+      if (!inferCompactDisplayForSmallScreenMode()) return;
+      await SmallScreenModeConfirmDialog.show(context, appState);
+    } catch (_) {}
   }
 
   // The device startup sequence

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -294,6 +294,8 @@ class MainPageState extends State<MainPage>
     appState.initialize().then((_) async {
       Telemetry.event("app_started", {"first_run": !appState.welcomeSeen});
 
+      AndroidPlatformSettings.applyImmersiveMode(appState.androidImmersiveMode);
+
       final session = await AudioSession.instance;
       await session.configure(
         // Configure the AudioSession
@@ -1426,6 +1428,7 @@ class MainPageState extends State<MainPage>
     super.didChangeAppLifecycleState(state);
 
     if (state == AppLifecycleState.resumed) {
+      AndroidPlatformSettings.applyImmersiveMode(appState.androidImmersiveMode);
       if (appState.restartPending) return;
       unawaited(_autoRetryConnectionOnResume());
       // Recover audio after returning to foreground (USB and native aux).

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2162,14 +2162,15 @@ class MainPageState extends State<MainPage>
                         return Column(
                           children: [
                             Expanded(
-                              child: Center(
+                              child: Align(
+                                alignment: Alignment.bottomCenter,
                                 child: ConstrainedBox(
                                   constraints: BoxConstraints(
                                       maxWidth: appState.smallScreenMode
                                           ? constraints.maxWidth
                                           : 700),
                                   child: Column(
-                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    mainAxisSize: MainAxisSize.min,
                                     children: [
                                       // Channel info
                                       () {
@@ -2426,7 +2427,8 @@ class MainPageState extends State<MainPage>
                                 ),
                               ),
                             ),
-                            // Contextual actions row
+                            // Match spacing above transport (SizedBox after Scan/Guide/Mix).
+                            const SizedBox(height: 12),
                             // Preset carousel at bottom
                             SizedBox(
                               height: 140,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2001,6 +2001,7 @@ class MainPageState extends State<MainPage>
         final int activePresets =
             appState.presets.where((p) => p.sid != 0).length;
         final bool bigAppBar = appState.smallScreenMode && isLandscape(context);
+        final double appBarIconSize = bigAppBar ? 44 : 32;
         return Stack(
           children: [
             Scaffold(
@@ -2014,7 +2015,7 @@ class MainPageState extends State<MainPage>
                     appState.signalQuality,
                     isAntennaConnected: appState.isAntennaConnected,
                   )),
-                  iconSize: bigAppBar ? 32 : 24,
+                  iconSize: appBarIconSize,
                   padding: EdgeInsets.all(bigAppBar ? 14 : 8),
                   constraints: BoxConstraints(
                     minWidth: bigAppBar ? 64 : 48,
@@ -2043,7 +2044,7 @@ class MainPageState extends State<MainPage>
                         icon: Icon(
                           appState.isScanActive ? Icons.close : Icons.scanner,
                         ),
-                        iconSize: bigAppBar ? 30 : 24,
+                        iconSize: appBarIconSize,
                         padding: EdgeInsets.all(bigAppBar ? 14 : 8),
                         constraints: BoxConstraints(
                           minWidth: bigAppBar ? 64 : 48,
@@ -2080,7 +2081,7 @@ class MainPageState extends State<MainPage>
                           ? 'Channel Update in Progress'
                           : 'Program Guide',
                       icon: const Icon(Icons.view_list),
-                      iconSize: bigAppBar ? 30 : 24,
+                      iconSize: appBarIconSize,
                       padding: EdgeInsets.all(bigAppBar ? 14 : 8),
                       constraints: BoxConstraints(
                         minWidth: bigAppBar ? 64 : 48,
@@ -2104,7 +2105,7 @@ class MainPageState extends State<MainPage>
                               ? Icons.close
                               : Icons.shuffle,
                         ),
-                        iconSize: bigAppBar ? 30 : 24,
+                        iconSize: appBarIconSize,
                         padding: EdgeInsets.all(bigAppBar ? 14 : 8),
                         constraints: BoxConstraints(
                           minWidth: bigAppBar ? 64 : 48,
@@ -2138,7 +2139,7 @@ class MainPageState extends State<MainPage>
                   ],
                   IconButton(
                     icon: const Icon(Icons.settings),
-                    iconSize: bigAppBar ? 30 : 24,
+                    iconSize: appBarIconSize,
                     padding: EdgeInsets.all(bigAppBar ? 14 : 8),
                     constraints: BoxConstraints(
                       minWidth: bigAppBar ? 64 : 48,

--- a/lib/platform/android_platform_settings.dart
+++ b/lib/platform/android_platform_settings.dart
@@ -12,4 +12,18 @@ class AndroidPlatformSettings {
     if (!isAvailable) return;
     await _channel.invokeMethod<void>('playStartupSilence');
   }
+
+  /// Hide status / navigation bars when [enabled], or show them when false.
+  /// Call after prefs load and when the user toggles the setting.
+  static void applyImmersiveMode(bool enabled) {
+    if (!isAvailable) return;
+    if (enabled) {
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+    } else {
+      SystemChrome.setEnabledSystemUIMode(
+        SystemUiMode.manual,
+        overlays: SystemUiOverlay.values,
+      );
+    }
+  }
 }

--- a/lib/platform/display_heuristics.dart
+++ b/lib/platform/display_heuristics.dart
@@ -1,0 +1,30 @@
+import 'dart:ui' as ui;
+
+/// Heuristic for whether to offer [AppState.smallScreenMode] on first run (before Welcome).
+///
+/// Uses the primary [FlutterView]'s logical size (physical pixels / [devicePixelRatio]),
+/// which matches Flutter's **dp** on Android. Tuned for phones and typical automotive
+/// head units (e.g. 800×480, 1024×600, 1280×720).
+bool inferCompactDisplayForSmallScreenMode() {
+  final ui.FlutterView? view = ui.PlatformDispatcher.instance.implicitView;
+  if (view == null) return false;
+
+  final double dpr = view.devicePixelRatio;
+  if (dpr <= 0) return false;
+
+  final ui.Size physical = view.physicalSize;
+  if (physical.width <= 0 || physical.height <= 0) return false;
+
+  final double logicalW = physical.width / dpr;
+  final double logicalH = physical.height / dpr;
+  final double shortest = logicalW < logicalH ? logicalW : logicalH;
+  final double longest = logicalW > logicalH ? logicalW : logicalH;
+
+  // Phones and very small tablets / HUs (short edge ~600 dp or below).
+  if (shortest <= 600) return true;
+
+  // Common automotive and 720p-class panels (e.g. 1280×720, wide 1024×600).
+  if (shortest <= 720 && longest <= 1480) return true;
+
+  return false;
+}

--- a/lib/storage/storage_data.dart
+++ b/lib/storage/storage_data.dart
@@ -223,6 +223,7 @@ class StorageData {
         case SaveDataType.playStartupSilence:
         case SaveDataType.smallScreenMode:
         case SaveDataType.safeAreaInsetScale:
+        case SaveDataType.androidImmersiveMode:
           record[key] = value;
           break;
       }
@@ -301,6 +302,7 @@ class StorageData {
         case SaveDataType.playStartupSilence:
         case SaveDataType.smallScreenMode:
         case SaveDataType.safeAreaInsetScale:
+        case SaveDataType.androidImmersiveMode:
           return record[key];
       }
     } catch (e, st) {
@@ -468,4 +470,5 @@ enum SaveDataType {
   playStartupSilence,
   smallScreenMode,
   safeAreaInsetScale,
+  androidImmersiveMode,
 }

--- a/lib/ui/log_level_picker.dart
+++ b/lib/ui/log_level_picker.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
+import 'package:provider/provider.dart';
+import 'package:orbit/app_state.dart';
+
+/// Order used in log level menus and the settings dialog.
+const List<Level> kLogLevelMenuOrder = <Level>[
+  Level.trace,
+  Level.debug,
+  Level.info,
+  Level.warning,
+  Level.error,
+  Level.fatal,
+  Level.off,
+];
+
+String logLevelDisplayName(Level level) {
+  switch (level) {
+    case Level.trace:
+      return 'Trace';
+    case Level.debug:
+      return 'Debug';
+    case Level.info:
+      return 'Info';
+    case Level.warning:
+      return 'Warning';
+    case Level.error:
+      return 'Error';
+    case Level.fatal:
+      return 'Fatal';
+    case Level.off:
+      return 'Off';
+    default:
+      return level.name;
+  }
+}
+
+/// Same choices as Settings → Debug → Logging → Log Level; persists via [AppState].
+Future<void> showLogLevelPickerDialog(
+  BuildContext context, {
+  bool showConfirmationSnackBar = true,
+}) async {
+  final appState = Provider.of<AppState>(context, listen: false);
+  final theme = Theme.of(context);
+
+  final Level? selected = await showDialog<Level>(
+    context: context,
+    builder: (BuildContext ctx) {
+      return AlertDialog(
+        title: const Text('Select Log Level'),
+        content: SizedBox(
+          width: 360,
+          child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: kLogLevelMenuOrder.length,
+            itemBuilder: (BuildContext listContext, int index) {
+              final level = kLogLevelMenuOrder[index];
+              final isSelected = appState.logLevel == level;
+              return ListTile(
+                leading: Icon(
+                  isSelected
+                      ? Icons.radio_button_checked
+                      : Icons.radio_button_unchecked,
+                  color: isSelected
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.onSurface,
+                ),
+                title: Text(logLevelDisplayName(level)),
+                onTap: () => Navigator.pop(listContext, level),
+              );
+            },
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+        ],
+      );
+    },
+  );
+
+  if (selected != null) {
+    appState.updateLogLevel(selected);
+    if (showConfirmationSnackBar && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Log level set to ${logLevelDisplayName(selected)}'),
+        ),
+      );
+    }
+  }
+}
+
+/// Tune icon; opens the same dialog as Settings → Log Level.
+/// Requires [Provider<AppState>] above for the tooltip label.
+class LogLevelPopupMenuButton extends StatelessWidget {
+  const LogLevelPopupMenuButton({super.key, this.dense = false});
+
+  /// Slightly smaller icon in the compact floating log toolbar.
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context) {
+    return Selector<AppState, Level>(
+      selector: (_, AppState s) => s.logLevel,
+      builder: (BuildContext context, Level currentLevel, Widget? _) {
+        return IconButton(
+          tooltip: 'Log level: ${logLevelDisplayName(currentLevel)}',
+          icon: Icon(
+            Icons.tune,
+            size: dense ? 20 : 24,
+          ),
+          onPressed: () => showLogLevelPickerDialog(context),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/log_overlay.dart
+++ b/lib/ui/log_overlay.dart
@@ -1,28 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:orbit/ui/log_viewer.dart';
 
-class LogOverlayHost extends StatefulWidget {
-  const LogOverlayHost({
-    super.key,
-    required this.child,
-    required this.enabled,
-  });
+class FloatingLogLayers extends StatefulWidget {
+  const FloatingLogLayers({super.key, required this.enabled});
 
-  final Widget child;
   final bool enabled;
 
   @override
-  State<LogOverlayHost> createState() => _LogOverlayHostState();
+  State<FloatingLogLayers> createState() => _FloatingLogLayersState();
 }
 
-class _LogOverlayHostState extends State<LogOverlayHost> {
+class _FloatingLogLayersState extends State<FloatingLogLayers> {
   bool _panelVisible = false;
 
   Offset _offset = const Offset(24, 90);
   Size _size = const Size(560, 320);
 
   @override
-  void didUpdateWidget(covariant LogOverlayHost oldWidget) {
+  void didUpdateWidget(covariant FloatingLogLayers oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!widget.enabled && _panelVisible) {
       _panelVisible = false;
@@ -56,75 +51,63 @@ class _LogOverlayHostState extends State<LogOverlayHost> {
 
   @override
   Widget build(BuildContext context) {
-    final mq = MediaQuery.of(context);
-    final screen = mq.size;
-    _size = _clampSize(_size, screen);
-    _offset = _clampOffset(_offset, _size, screen);
+    if (!widget.enabled) {
+      return const IgnorePointer(
+        ignoring: true,
+        child: SizedBox.expand(),
+      );
+    }
 
-    return Overlay(
-      initialEntries: [
-        OverlayEntry(
-          builder: (_) {
-            return Stack(
-              children: [
-                widget.child,
-                if (widget.enabled) ...[
-                  Positioned(
-                    right: 12,
-                    bottom: 12 + mq.padding.bottom,
-                    child: AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 150),
-                      child: _panelVisible
-                          ? const SizedBox.shrink()
-                          : FloatingActionButton.small(
-                              key: const ValueKey<String>('log_overlay_button'),
-                              tooltip: 'Show log overlay',
-                              onPressed: () {
-                                setState(() {
-                                  _panelVisible = true;
-                                });
-                              },
-                              child: const Icon(Icons.article_outlined),
-                            ),
-                    ),
-                  ),
-                  if (_panelVisible)
-                    Positioned(
-                      left: _offset.dx,
-                      top: _offset.dy,
-                      width: _size.width,
-                      height: _size.height,
-                      child: _OverlayPanel(
-                        onClose: () {
-                          setState(() {
-                            _panelVisible = false;
-                          });
-                        },
-                        onDragDelta: (delta) {
-                          setState(() {
-                            _offset =
-                                _clampOffset(_offset + delta, _size, screen);
-                          });
-                        },
-                        onResizeDelta: (delta) {
-                          setState(() {
-                            _size = _clampSize(
-                              Size(
-                                _size.width + delta.dx,
-                                _size.height + delta.dy,
-                              ),
-                              screen,
-                            );
-                            _offset = _clampOffset(_offset, _size, screen);
-                          });
-                        },
-                      ),
-                    ),
-                ],
-              ],
-            );
-          },
+    final MediaQueryData mq = MediaQuery.of(context);
+    final Size screen = mq.size;
+    final Size size = _clampSize(_size, screen);
+    final Offset offset = _clampOffset(_offset, size, screen);
+
+    return Stack(
+      fit: StackFit.expand,
+      clipBehavior: Clip.none,
+      children: <Widget>[
+        Positioned.fill(
+          child: IgnorePointer(
+            ignoring: true,
+            child: const SizedBox.expand(),
+          ),
         ),
+        if (!_panelVisible)
+          Positioned(
+            right: 12,
+            bottom: 12 + mq.padding.bottom,
+            child: FloatingActionButton.small(
+              key: const ValueKey<String>('log_overlay_button'),
+              tooltip: 'Show log overlay',
+              onPressed: () => setState(() => _panelVisible = true),
+              child: const Icon(Icons.article_outlined),
+            ),
+          ),
+        if (_panelVisible)
+          Positioned(
+            left: offset.dx,
+            top: offset.dy,
+            width: size.width,
+            height: size.height,
+            child: _OverlayPanel(
+              onClose: () => setState(() => _panelVisible = false),
+              onDragDelta: (Offset delta) {
+                setState(() {
+                  _offset = _clampOffset(_offset + delta, _size, screen);
+                });
+              },
+              onResizeDelta: (Offset delta) {
+                setState(() {
+                  _size = _clampSize(
+                    Size(_size.width + delta.dx, _size.height + delta.dy),
+                    screen,
+                  );
+                  _offset = _clampOffset(_offset, _size, screen);
+                });
+              },
+            ),
+          ),
       ],
     );
   }
@@ -161,7 +144,7 @@ class _OverlayPanel extends StatelessWidget {
               children: [
                 GestureDetector(
                   behavior: HitTestBehavior.opaque,
-                  onPanUpdate: (d) => onDragDelta(d.delta),
+                  onPanUpdate: (DragUpdateDetails d) => onDragDelta(d.delta),
                   child: Container(
                     height: 44,
                     padding: const EdgeInsets.symmetric(horizontal: 10),
@@ -193,7 +176,7 @@ class _OverlayPanel extends StatelessWidget {
               bottom: 2,
               child: GestureDetector(
                 behavior: HitTestBehavior.opaque,
-                onPanUpdate: (d) => onResizeDelta(d.delta),
+                onPanUpdate: (DragUpdateDetails d) => onResizeDelta(d.delta),
                 child: Padding(
                   padding: const EdgeInsets.all(6),
                   child: Icon(

--- a/lib/ui/log_viewer.dart
+++ b/lib/ui/log_viewer.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:orbit/logging.dart';
+import 'package:orbit/ui/log_level_picker.dart';
 import 'package:universal_io/io.dart';
 
 class LogViewerPage extends StatelessWidget {
@@ -253,6 +254,7 @@ class _LogViewerState extends State<LogViewer> {
                   _maybeFollow();
                 },
               ),
+              LogLevelPopupMenuButton(dense: isCompact),
               if (!isCompact)
                 IconButton(
                   tooltip: 'Reload from file tail',

--- a/lib/ui/settings.dart
+++ b/lib/ui/settings.dart
@@ -260,6 +260,19 @@ class SettingsPage extends StatelessWidget {
               'Appearance',
               Icons.palette,
               [
+                if (!kIsWeb && !kIsWasm && Platform.isAndroid) ...[
+                  _buildSwitchTile(
+                    context,
+                    'Immersive Mode',
+                    'Hide status and navigation bars (fullscreen)',
+                    Icons.fullscreen,
+                    value: appState.androidImmersiveMode,
+                    onChanged: (value) {
+                      appState.updateAndroidImmersiveMode(value);
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                ],
                 _buildSwitchTile(
                   context,
                   'Small Screen Mode',

--- a/lib/ui/settings.dart
+++ b/lib/ui/settings.dart
@@ -25,6 +25,7 @@ import 'package:orbit/storage/storage_data.dart';
 import 'package:orbit/ui/presets_editor.dart';
 import 'package:orbit/ui/favorites_manager.dart';
 import 'package:orbit/ui/log_viewer.dart';
+import 'package:orbit/ui/log_level_picker.dart';
 import 'package:orbit/ui/favorites_on_air_dialog.dart';
 import 'package:orbit/ui/signal_bar.dart';
 import 'package:orbit/ui/streaming_beta.dart';
@@ -34,7 +35,6 @@ import 'package:orbit/sxi_command_types.dart';
 import 'package:orbit/sxi_commands.dart';
 import 'package:orbit/sxi_indication_types.dart';
 import 'package:orbit/logging.dart';
-import 'package:logger/logger.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:universal_io/io.dart';
@@ -679,9 +679,9 @@ class SettingsPage extends StatelessWidget {
                     _buildSettingTile(
                       context,
                       'Log Level',
-                      _logLevelLabel(appState.logLevel),
+                      logLevelDisplayName(appState.logLevel),
                       Icons.report,
-                      onTap: () => _showLogLevelDialog(context),
+                      onTap: () => showLogLevelPickerDialog(context),
                     ),
                     _buildSwitchTile(
                       context,
@@ -1054,89 +1054,6 @@ class SettingsPage extends StatelessWidget {
         dsi,
       ),
     );
-  }
-
-  String _logLevelLabel(Level level) {
-    switch (level) {
-      case Level.trace:
-        return 'Trace';
-      case Level.debug:
-        return 'Debug';
-      case Level.info:
-        return 'Info';
-      case Level.warning:
-        return 'Warning';
-      case Level.error:
-        return 'Error';
-      case Level.fatal:
-        return 'Fatal';
-      case Level.off:
-        return 'Off';
-      default:
-        return level.name;
-    }
-  }
-
-  Future<void> _showLogLevelDialog(BuildContext context) async {
-    final appState = Provider.of<AppState>(context, listen: false);
-    final theme = Theme.of(context);
-    final levels = <Level>[
-      Level.trace,
-      Level.debug,
-      Level.info,
-      Level.warning,
-      Level.error,
-      Level.fatal,
-      Level.off,
-    ];
-
-    final selected = await showDialog<Level>(
-      context: context,
-      builder: (ctx) {
-        return AlertDialog(
-          title: const Text('Select Log Level'),
-          content: SizedBox(
-            width: 360,
-            child: ListView.builder(
-              shrinkWrap: true,
-              itemCount: levels.length,
-              itemBuilder: (context, index) {
-                final level = levels[index];
-                final isSelected = appState.logLevel == level;
-                return ListTile(
-                  leading: Icon(
-                    isSelected
-                        ? Icons.radio_button_checked
-                        : Icons.radio_button_unchecked,
-                    color: isSelected
-                        ? theme.colorScheme.primary
-                        : theme.colorScheme.onSurface,
-                  ),
-                  title: Text(_logLevelLabel(level)),
-                  onTap: () => Navigator.pop(context, level),
-                );
-              },
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('Cancel'),
-            ),
-          ],
-        );
-      },
-    );
-
-    if (selected != null) {
-      appState.updateLogLevel(selected);
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-              content: Text('Log level set to ${_logLevelLabel(selected)}')),
-        );
-      }
-    }
   }
 
   Widget _buildSection(

--- a/lib/ui/small_screen_mode_confirm_dialog.dart
+++ b/lib/ui/small_screen_mode_confirm_dialog.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:orbit/app_state.dart';
+
+/// First-run only: shown when [AppState.welcomeSeen] is false and the display
+/// heuristic suggests compact / automotive layouts, so the user can opt in
+/// to Small Screen Mode instead of having it applied automatically.
+class SmallScreenModeConfirmDialog extends StatelessWidget {
+  final AppState appState;
+
+  const SmallScreenModeConfirmDialog({super.key, required this.appState});
+
+  static Future<void> show(BuildContext context, AppState appState) async {
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) =>
+          SmallScreenModeConfirmDialog(appState: appState),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final onSurface = theme.colorScheme.onSurface;
+
+    return AlertDialog(
+      title: const Text('Small Screen Mode'),
+      content: SizedBox(
+        width: 400,
+        child: Text(
+          'This display looks compact. Small Screen Mode uses larger touch '
+          'targets and a simplified layout. Do you want to use it?',
+          style: TextStyle(fontSize: 16, color: onSurface),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            appState.updateSmallScreenMode(false);
+            Navigator.of(context).pop();
+          },
+          child: const Text('Standard layout'),
+        ),
+        FilledButton(
+          onPressed: () {
+            appState.updateSmallScreenMode(true);
+            Navigator.of(context).pop();
+          },
+          child: const Text('Use Small Screen Mode'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/welcome_dialog.dart
+++ b/lib/ui/welcome_dialog.dart
@@ -33,8 +33,8 @@ class WelcomeDialog extends StatelessWidget {
           Image.asset('assets/icon/icon.png', width: 32, height: 32),
         ],
       ),
-      content: SizedBox(
-        width: 420,
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 560),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
a handful of UI tweaks targeted at Android-based HUs with a 1280x720 screen:

- ensure transport bar not hidden below favorites icons
- Add optional Immersive Mode on Android
- increase size of top-row icons by ~33%
- drop notification when successfully switching HU to aux audio
- auto-enable Small Screen Mode for Android based on screen DPI
- prevent text wrapping on Welcome dialog when SSM used
- rework floating log display to allow for changing logging level on the fly